### PR TITLE
Fix profiling on pwd search task

### DIFF
--- a/apps/experiments/src/experiments.erl
+++ b/apps/experiments/src/experiments.erl
@@ -12,10 +12,8 @@ usage(Io) ->
     io:format(Io, "    matrix       run the 'matrix multiplication' case study~n", []),
     io:format(Io, "~n", []).
 
-main(["pwd", NMasters, NWorkers, NPwds]) ->
-    pwd_search:pwd_search_task(list_to_integer(NMasters), 
-        list_to_integer(NWorkers), 
-        list_to_integer(NPwds));    
+main(["pwd", NWorkers, NPwds]) ->
+    pwd_search:pwd_search_task(list_to_integer(NWorkers), list_to_integer(NPwds));    
 main(["matrix"]) ->
     io:format("TODO: Matrix multiplication step is not implemented yet");    
 main(["-h"]) ->

--- a/apps/experiments/src/nodelib.erl
+++ b/apps/experiments/src/nodelib.erl
@@ -6,7 +6,7 @@
     run_on_node/2,
     init_sup/0,
     get_supervisor/0,
-    wait_for_nodes/1
+    wait_for_master/0
 ]).
 
 % Init the supervisor node
@@ -55,12 +55,9 @@ run_on_node(Node, Fun) ->
     spawn(Node, Fun),
     ok.
 
-% Wait for the completion of N nodes
--spec wait_for_nodes(N :: integer()) -> ok.
-wait_for_nodes(0) -> ok;
-wait_for_nodes(N) ->
+% Wait for the master node to complete the execution
+-spec wait_for_master() -> ok.
+wait_for_master() ->
     receive
-        {finished, Node} ->
-            io:format("Node '~p' has finish~n", [Node]),
-            wait_for_nodes(N-1)
+        {finished, M} -> io:format("Master node '~p' has finish~n", [M])
     end.


### PR DESCRIPTION
This PR will fix some minor mistakes in profiling the password search task:

- the names of the events are more representative (from read_task to search_hash)
- the cumulative event on the master now works